### PR TITLE
Pull request 03/27/2025

### DIFF
--- a/src/Tokenizer/Token.hs
+++ b/src/Tokenizer/Token.hs
@@ -44,4 +44,4 @@ module Tokenizer.Token (
          | IntegerToken Int
          | IdentifierToken String 
          | StructNameToken String
-          deriving (Show, Eq,Read)
+          deriving (Show, Eq)

--- a/src/Tokenizer/Tokenizer.hs
+++ b/src/Tokenizer/Tokenizer.hs
@@ -65,7 +65,7 @@ tryReadSymbolToken ':' = Just ColonToken
 tryReadSymbolToken ';' = Just SemiColonToken
 tryReadSymbolToken _ = Nothing
 
--- | The main tokenizing function
+
 
 
 stripWhiteSpace :: String -> [String]
@@ -80,7 +80,7 @@ validLeftOver (x : xs) -- Take from the first character
    | isAlpha x = False
    | otherwise = True
      
-
+-- | The main tokenizing function
 tokenize :: String -> Either String [Token]
 tokenize input = 
      let strippedInput = stripWhiteSpace (removeComments input) --Remove comments before we strip all whitespace

--- a/src/Tokenizer/Tokenizer.hs
+++ b/src/Tokenizer/Tokenizer.hs
@@ -84,14 +84,15 @@ validLeftOver (x : xs) -- Take from the first character
 tokenize :: String -> Either String [Token]
 tokenize input = 
      let strippedInput = stripWhiteSpace (removeComments input) --Remove comments before we strip all whitespace
-     in tokenizeStripped strippedInput -- Strip all whitespace and go through the "words" list
+     in tokenizeStrippedWords strippedInput -- Strip all whitespace and go through the "words" list
       
 -- Simply just tokenization loop but we use it on each "word" and add tokens
-tokenizeStripped :: [String] -> Either String [Token]
-tokenizeStripped [] =  Right [] --Nothing in input string, base case     
-tokenizeStripped (word:rest) = do 
-    tokensfromCurrent <- tokenizationLoop word
-    tokensfromRest <- tokenizeStripped rest
+-- It should just basically be the exact logic as tokenizationLoop but goes through
+tokenizeStrippedWords :: [String] -> Either String [Token]
+tokenizeStrippedWords [] =  Right [] --Nothing in input string, base case     
+tokenizeStrippedWords (word:rest) = do 
+    tokensfromCurrent <- tokenizationLoop word --Tokenize current "word"
+    tokensfromRest <- tokenizeStrippedWords rest    -- Tokenize the rest of the word list
     return (tokensfromCurrent ++ tokensfromRest)
 
 

--- a/src/Tokenizer/Tokenizer.hs
+++ b/src/Tokenizer/Tokenizer.hs
@@ -1,6 +1,7 @@
 
 module Tokenizer.Tokenizer (
-  tokenize
+  tokenize,
+  stripWhiteSpace
 ) where
 
 import Data.Char
@@ -65,8 +66,34 @@ tryReadSymbolToken ';' = Just SemiColonToken
 tryReadSymbolToken _ = Nothing
 
 -- | The main tokenizing function
+
+
+stripWhiteSpace :: String -> [String]
+stripWhiteSpace "" = []
+stripWhiteSpace input = words input
+
+--Determines if the left over string in the second list of span tuple is valid.
+-- This should only really be used in handleNumber, as 123abc for example should not be a valid token
+validLeftOver :: String -> Bool 
+validLeftOver "" = True -- no more left over words, so automatically a valid integer
+validLeftOver (x : xs) -- Take from the first character 
+   | isAlpha x = False
+   | otherwise = True
+     
+
 tokenize :: String -> Either String [Token]
-tokenize = tokenizationLoop.removeLeadingWhiteSpace.removeComments
+tokenize input = 
+     let strippedInput = stripWhiteSpace (removeComments input) --Remove comments before we strip all whitespace
+     in tokenizeStripped strippedInput -- Strip all whitespace and go through the "words" list
+      
+-- Simply just tokenization loop but we use it on each "word" and add tokens
+tokenizeStripped :: [String] -> Either String [Token]
+tokenizeStripped [] =  Right [] --Nothing in input string, base case     
+tokenizeStripped (word:rest) = do 
+    tokensfromCurrent <- tokenizationLoop word
+    tokensfromRest <- tokenizeStripped rest
+    return (tokensfromCurrent ++ tokensfromRest)
+
 
 tokenizationLoop :: String -> Either String [Token]
 -- base case
@@ -101,7 +128,10 @@ handleNumber firstNum restOfInputString =
   let (numbers, leftoverString) = span isDigit restOfInputString
       wholeNumber = firstNum : numbers
    in case readMaybe wholeNumber of
-        Just intValue -> Right (IntegerToken intValue, leftoverString)
+        Just intValue ->
+         if validLeftOver leftoverString -- if nothing within leftoverString or leftover doesn't start with a letter, valid integer.
+            then Right (IntegerToken intValue, leftoverString)
+            else Left ("Invalid integer: " ++ wholeNumber ++ leftoverString)      
         Nothing -> Left ("Invalid integer: " ++ wholeNumber)
 
 handleSymbol :: String -> Either String (Token, String)

--- a/test/test.hs
+++ b/test/test.hs
@@ -10,51 +10,51 @@ tests :: TestTree
 tests = testGroup "Tokenizer Tests"
   [   
      testCase "Testing tokenization of assignment expression" $
-      either assertFailure (@?= [IdentifierToken "a1", EqualToken, IntegerToken 5]) (tokenize "a1 = 5")
+      either assertFailure (@=? [IdentifierToken "a1", EqualToken, IntegerToken 5]) (tokenize "a1 = 5")
   ,
      testCase "Tokenize binary addition operations" $
-      either assertFailure (@?= [IntegerToken 5, AddToken, IntegerToken 5]) (tokenize "5 + 5")
+      either assertFailure (@=? [IntegerToken 5, AddToken, IntegerToken 5]) (tokenize "5 + 5")
   ,
      testCase "Tokenize trinary addition operations" $
-      either assertFailure (@?= [IntegerToken 5, AddToken, IntegerToken 5, AddToken, IntegerToken 10]) (tokenize "5 + 5 + 10")
+      either assertFailure (@=? [IntegerToken 5, AddToken, IntegerToken 5, AddToken, IntegerToken 10]) (tokenize "5 + 5 + 10")
   , 
      testCase "Tokenize parentheses and braces" $
-      either assertFailure (@?= [LParenToken, IdentifierToken "x", RParenToken, LBraceToken, RBraceToken]) (tokenize "(x) {}")
+      either assertFailure (@=? [LParenToken, IdentifierToken "x", RParenToken, LBraceToken, RBraceToken]) (tokenize "(x) {}")
   , 
      testCase "Tokenize comparison operators" $
-      either assertFailure (@?= [IdentifierToken "x", GreaterThanToken, IdentifierToken "y", LessThanToken, IdentifierToken "z"]) (tokenize "x > y < z")
+      either assertFailure (@=? [IdentifierToken "x", GreaterThanToken, IdentifierToken "y", LessThanToken, IdentifierToken "z"]) (tokenize "x > y < z")
   , 
      testCase "Tokenize keywords" $
-      either assertFailure (@?= [IfToken, IdentifierToken "x", ReturnToken, IntegerToken 42]) (tokenize "if x return 42")
+      either assertFailure (@=? [IfToken, IdentifierToken "x", ReturnToken, IntegerToken 42]) (tokenize "if x return 42")
   , 
      testCase "Tokenize boolean literals" $
-      either assertFailure (@?= [TrueToken, FalseToken]) (tokenize "true false")
+      either assertFailure (@=? [TrueToken, FalseToken]) (tokenize "true false")
   , 
      testCase "Tokenize struct and trait keywords" $
-      either assertFailure (@?= [StructToken, IdentifierToken "MyStruct", TraitToken, IdentifierToken "MyTrait"]) (tokenize "struct MyStruct trait MyTrait")
+      either assertFailure (@=? [StructToken, IdentifierToken "MyStruct", TraitToken, IdentifierToken "MyTrait"]) (tokenize "struct MyStruct trait MyTrait")
   , 
      testCase "Tokenize multi-character symbols" $
-      either assertFailure (@?= [ArrowToken, EqualsToken, NotEqualToken]) (tokenize "=> == !=")
+      either assertFailure (@=? [ArrowToken, EqualsToken, NotEqualToken]) (tokenize "=> == !=")
   , 
      testCase "Tokenize miscellaneous symbols" $
-      either assertFailure (@?= [CommaToken, ColonToken, SemiColonToken]) (tokenize ", : ;")
+      either assertFailure (@=? [CommaToken, ColonToken, SemiColonToken]) (tokenize ", : ;")
   , 
      testCase "Tokenize identifiers and integers" $
-      either assertFailure (@?= [IdentifierToken "var1", IntegerToken 123, IdentifierToken "var2", IntegerToken 456]) (tokenize "var1 123 var2 456")
+      either assertFailure (@=? [IdentifierToken "var1", IntegerToken 123, IdentifierToken "var2", IntegerToken 456]) (tokenize "var1 123 var2 456")
   , 
      testCase "Tokenize with comments" $
-      either assertFailure (@?= [LetToken, IdentifierToken "x", EqualToken, IntegerToken 10, SemiColonToken]) (tokenize "let x = 10; // This is a comment")
+      either assertFailure (@=? [LetToken, IdentifierToken "x", EqualToken, IntegerToken 10, SemiColonToken]) (tokenize "let x = 10; // This is a comment")
   ,
      testCase "Tokenize Int, Void, Boolean, Else, While, PrintLn, Self, Method, Break, Impl, New, For" $
-      either assertFailure (@?= [IntToken, VoidToken, BooleanToken, ElseToken, WhileToken, PrintLnToken, SelfToken, MethodToken, BreakToken, ImplToken, NewToken, ForToken]) 
+      either assertFailure (@=? [IntToken, VoidToken, BooleanToken, ElseToken, WhileToken, PrintLnToken, SelfToken, MethodToken, BreakToken, ImplToken, NewToken, ForToken]) 
       (tokenize "Int Void Boolean else while println Self method break impl new for")
   ,
      testCase "Tokenize Subtract, Multiply, Divide tokens" $
-      either assertFailure (@?= [IntegerToken 10, SubtractToken, IntegerToken 5, MultiplyToken, IntegerToken 2, DivideToken, IntegerToken 4]) 
+      either assertFailure (@=? [IntegerToken 10, SubtractToken, IntegerToken 5, MultiplyToken, IntegerToken 2, DivideToken, IntegerToken 4]) 
       (tokenize "10 - 5 * 2 / 4")
   ,
     testCase "Tokenize WhileIf" $
-     either assertFailure (@?= [IdentifierToken "WhileIf"]) (tokenize "WhileIf")
+     either assertFailure (@=? [IdentifierToken "WhileIf"]) (tokenize "WhileIf")
   ,
      testCase "Unrecognized symbol error message" $
       tokenize "$" @?= Left "Unrecognized symbol near here `: $`"
@@ -66,5 +66,29 @@ tests = testGroup "Tokenizer Tests"
      testCase "Invalid integer error message" $
       tokenize "123abc" @?= Left "Invalid integer: 123abc"
 
-  
+  , 
+   testCase "Testing Token derived Show" $
+    case tokenize "5" of
+     Right tokens -> show tokens @?= "[IntegerToken 5]"
+     Left err -> assertFailure err
+  ,
+   testCase "Test that Tokens can equal each other" $
+    AddToken @?= AddToken
+  , 
+    testCase "ArrowTokens equal each other" $
+    ArrowToken == ArrowToken @?= True
+  ,
+    testCase "test that different tokens do not equal" $
+    False @=? AddToken == SubtractToken 
+  , 
+    testCase "another test that different tokens do not equal" $
+    AddToken /= DivideToken @?= True
+
+  , 
+    testCase "List of Tokens can equal each other" $
+      [IdentifierToken "hi", AddToken, IntegerToken 5] == [IdentifierToken "hi", AddToken, IntegerToken 5] @?= True
+
+  , 
+    testCase "List of Tokens are not equal if mismatched values" $
+      [IdentifierToken "hi", AddToken, IntegerToken 5] == [IdentifierToken "hi", SubtractToken, IntegerToken 5] @?= False
   ]

--- a/test/test.hs
+++ b/test/test.hs
@@ -53,11 +53,15 @@ tests = testGroup "Tokenizer Tests"
       either assertFailure (@?= [IntegerToken 10, SubtractToken, IntegerToken 5, MultiplyToken, IntegerToken 2, DivideToken, IntegerToken 4]) 
       (tokenize "10 - 5 * 2 / 4")
   ,
+    testCase "Tokenize WhileIf" $
+     either assertFailure (@?= [IdentifierToken "WhileIf"]) (tokenize "WhileIf")
+  ,
      testCase "Unrecognized symbol error message" $
       tokenize "$" @?= Left "Unrecognized symbol near here `: $`"
   ,
      testCase "unrecognized symbol error within a more comprehensive input string" $
        tokenize "let a1 $ 5" @?= Left "Unrecognized symbol near here `: $`"
+    
   ,
      testCase "Invalid integer error message" $
       tokenize "123abc" @?= Left "Invalid integer: 123abc"

--- a/test/test.hs
+++ b/test/test.hs
@@ -47,7 +47,7 @@ tests = testGroup "Tokenizer Tests"
   ,
      testCase "Tokenize Int, Void, Boolean, Else, While, PrintLn, Self, Method, Break, Impl, New, For" $
       either assertFailure (@?= [IntToken, VoidToken, BooleanToken, ElseToken, WhileToken, PrintLnToken, SelfToken, MethodToken, BreakToken, ImplToken, NewToken, ForToken]) 
-      (tokenize "Int Void Boolean else while println self method break impl new for")
+      (tokenize "Int Void Boolean else while println Self method break impl new for")
   ,
      testCase "Tokenize Subtract, Multiply, Divide tokens" $
       either assertFailure (@?= [IntegerToken 10, SubtractToken, IntegerToken 5, MultiplyToken, IntegerToken 2, DivideToken, IntegerToken 4]) 
@@ -56,6 +56,11 @@ tests = testGroup "Tokenizer Tests"
      testCase "Unrecognized symbol error message" $
       tokenize "$" @?= Left "Unrecognized symbol near here `: $`"
   ,
+     testCase "unrecognized symbol error within a more comprehensive input string" $
+       tokenize "let a1 $ 5" @?= Left "Unrecognized symbol near here `: $`"
+  ,
      testCase "Invalid integer error message" $
       tokenize "123abc" @?= Left "Invalid integer: 123abc"
+
+  
   ]


### PR DESCRIPTION
### Added
tokenizeStrippedWords added, which essentially is just taking the list of strings taken from StripWhiteSpace and applying tokenizationLoop to each "word".  

validLeftOver which is mostly for handleNumber so if the leftoverString isn't a symbol or empty, say 123abc. Then that's an invalid integer. 

stripWhiteSpace returns.

### Modified
handleNumber was modified to use validLeftOver.  if true, then a valid integerToken and continue with the tokenization loop, 
else, invalid integerToken.


All 18 tests pass.